### PR TITLE
Staged diff minor improvements

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/pages/StagingTreeView/DiffTable.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/pages/StagingTreeView/DiffTable.vue
@@ -106,6 +106,9 @@
           const type = labelsMap[key];
           const live = this.stagingDiff[key].live;
           const staged = this.stagingDiff[key].staged;
+          if (live === 0 && staged === 0) {
+            return; // skip content kinds not present in channel
+          }
           const diff = staged - live;
 
           return { key, type, live, staged, diff };

--- a/contentcuration/contentcuration/frontend/channelEdit/views/TreeView/index.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/views/TreeView/index.vue
@@ -18,9 +18,7 @@
             :to="stagingTreeLink"
             :style="{'text-decoration': 'underline'}"
             data-test="staging-tree-link"
-          >
-            {{ $tr('updatedResourcesReadyForReview') }}
-          </router-link>
+          >{{ $tr('updatedResourcesReadyForReview') }}</router-link>
           (<time :datetime="channelModifiedDate">{{ prettyChannelModifiedDate }}</time>)
         </span>
       </VLayout>

--- a/contentcuration/contentcuration/frontend/channelEdit/vuex/currentChannel/mutations.js
+++ b/contentcuration/contentcuration/frontend/channelEdit/vuex/currentChannel/mutations.js
@@ -3,7 +3,6 @@ export function SAVE_CURRENT_CHANNEL_STAGING_DIFF(state, payload) {
   // (can be removed after API is updated)
   const fieldsMap = {
     'Date/Time Created': 'date_created',
-    'Ricecooker Version': 'ricecooker_version',
     'File Size': 'file_size_in_bytes',
     '# of Topics': 'count_topics',
     '# of Videos': 'count_videos',
@@ -15,6 +14,7 @@ export function SAVE_CURRENT_CHANNEL_STAGING_DIFF(state, payload) {
     '# of H5Ps': 'count_h5ps',
     '# of Questions': 'count_questions',
     '# of Subtitles': 'count_subtitles',
+    'Ricecooker Version': 'ricecooker_version',
   };
 
   const stagingDiff = {};

--- a/contentcuration/contentcuration/views/internal.py
+++ b/contentcuration/contentcuration/views/internal.py
@@ -225,12 +225,7 @@ def api_commit_channel(request):
         # we ACTIVATE the channel, i.e., set the main tree from the staged tree
         if not data.get('stage'):
             try:
-                activate_channel(obj, request.user)
-                # Prepare change event indicating new root_id
-                event = generate_update_event(channel_id, CHANNEL, {
-                    "root_id": obj.main_tree.id,
-                    "staging_root_id": None,
-                })
+                event = activate_channel(obj, request.user)
             except PermissionDenied as e:
                 return Response(str(e), status=e.status_code)
 


### PR DESCRIPTION
Three small fixes:

1/ During review we had decided "Ricecooker Version" is the least important info so can appear last in table:
<img width="416" alt="Screen Shot 2020-07-21 at 3 25 35 PM" src="https://user-images.githubusercontent.com/163966/88121569-1ff57600-cb94-11ea-9373-c5f71d69bb12.png">


2/ Due to default linting rules, there was an extra space appearing:
<img width="574" alt="Screen Shot 2020-07-21 at 8 49 35 PM" src="https://user-images.githubusercontent.com/163966/88121632-5b904000-cb94-11ea-882f-33c8a64c82e0.png">
so I changed to this:
<img width="1142" alt="improved spacing" src="https://user-images.githubusercontent.com/163966/88121652-6ba81f80-cb94-11ea-80ef-c453546aef76.png">
which seems like an improvement

3/ Added a rule to skip content kinds that are not present at all in the channel
e.g. if Khan Academy has only videos and exercises, no need to tell users there were 0 documents in the live version, and 0 documents in the staging version.


